### PR TITLE
CI: Add JDK 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['17', '21']
+        java: ['17', '21', '25']
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Add JDK 25 to the CI test matrix
- Test matrix is now: JDK 17, 21, 25