### PR TITLE
[codex] add flush and drain connection controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A lightweight ZIO 2.x wrapper around the official Java NATS client (jnats).
 Features:
 - ZLayer-based managed connection acquisition & clean shutdown via `Nats.live` / `Nats.liveZIO`
 - Simple publish & request APIs (string or byte array)
+- Basic connection controls like `flush` and `drain`
 - Streaming consume API via ZStream using a NATS Dispatcher bridged through a ZIO Queue
 - Minimal service (`Nats`) you pull from the environment with `ZIO.service[Nats]`
 - Configurable via ZIO Config (env vars or system properties by default)

--- a/zioNats/src/zio/nats/Nats.scala
+++ b/zioNats/src/zio/nats/Nats.scala
@@ -41,6 +41,8 @@ trait Nats:
     publish(subject, data.toArray)
   def publishString(subject: String, data: String, charset: Charset = StandardCharsets.UTF_8): Task[Unit] =
     publish(subject, data.getBytes(charset))
+  def flush(timeout: Duration = 1.second): Task[Unit]
+  def drain(timeout: Duration = 1.second): Task[Unit]
   def request(subject: String, data: Array[Byte], timeout: Duration): Task[NatsMessage]
   def request(subject: String, data: Array[Byte]): Task[NatsMessage]                                      =
     request(subject, data, 5.seconds)
@@ -106,6 +108,12 @@ object Nats:
         new Nats:
           override def publish(subject: String, data: Array[Byte]): Task[Unit] =
             ZIO.attemptBlocking(conn.publish(subject, data))
+
+          override def flush(timeout: Duration): Task[Unit] =
+            ZIO.attemptBlocking(conn.flush(timeout)).unit
+
+          override def drain(timeout: Duration): Task[Unit] =
+            ZIO.fromCompletableFuture(conn.drain(timeout)).unit
 
           override def request(subject: String, data: Array[Byte], timeout: Duration): Task[NatsMessage] =
             ZIO.attemptBlocking {

--- a/zioNats/test/src/zio/nats/NatsSpec.scala
+++ b/zioNats/test/src/zio/nats/NatsSpec.scala
@@ -10,12 +10,22 @@ object NatsSpec extends ZIOSpecDefault:
     suite("NatsSpec")(
       test("publishString -> subscribe single message") {
         for
-          nats   <- ZIO.service[Nats]
-          subject = "test.subject1"
-          fiber  <- nats.subscribe(subject).take(1).runCollect.fork
+          subject <- Random.nextUUID.map(u => s"test.subject.${u.toString}")
+          nats    <- ZIO.service[Nats]
+          got     <- Promise.make[Nothing, String]
+          fiber   <- nats
+                       .subscribe(subject)
+                       .take(1)
+                       .foreach(msg => got.succeed(msg.asString()).unit)
+                       .fork
+          _      <- nats.flush()
+          _      <- ZIO.sleep(1.second)
           _      <- nats.publishString(subject, "hello-nats").delay(100.millis)
-          msgs   <- fiber.join
-        yield assertTrue(msgs.head.asString() == "hello-nats")
+          _      <- nats.flush()
+          msgOpt  <- got.await.timeout(10.seconds)
+          _       <- fiber.interrupt
+          msg     <- ZIO.fromOption(msgOpt)
+        yield assertTrue(msg == "hello-nats")
       },
       test("request/reply round trip") {
         for
@@ -31,6 +41,14 @@ object NatsSpec extends ZIOSpecDefault:
           resp      <- nats.requestString(subject, "ping", 2.seconds).delay(100.millis)
           _         <- responder.join
         yield assertTrue(resp == "ping-ok")
+      },
+      test("flush completes on an active connection") {
+        for
+          subject <- Random.nextUUID.map(u => s"test.flush.${u.toString}")
+          nats    <- ZIO.service[Nats]
+          _       <- nats.publishString(subject, "hello")
+          _       <- nats.flush()
+        yield assertTrue(true)
       },
       test("queue group distributes messages across subscribers") {
         for
@@ -59,6 +77,14 @@ object NatsSpec extends ZIOSpecDefault:
           msg     <- ZIO.fromOption(msgOpt)
           fake     = msg.copy(replyTo = None) // simulate missing replyTo
           result  <- nats.replyString(fake, "data").either
+        yield assertTrue(result.isLeft)
+      },
+      test("drain closes the underlying connection for subsequent publishes") {
+        for
+          subject <- Random.nextUUID.map(u => s"test.drain.${u.toString}")
+          nats    <- ZIO.service[Nats]
+          _       <- nats.drain()
+          result  <- nats.publishString(subject, "after-drain").either
         yield assertTrue(result.isLeft)
       }
     ).provideLayerShared(


### PR DESCRIPTION
## What changed
- Added `flush(timeout: Duration)` and `drain(timeout: Duration)` to the `Nats` service API.
- Wired both methods into the live Java client implementation.
- Expanded the test suite to cover publish/subscribe, request/reply, flush, queue groups, missing replyTo, and drain behavior.
- Updated the README to mention the new connection controls.

## Why
The bounty asks for more complete basic client operations on top of the official Java NATS client. `flush` and `drain` are useful connection-control primitives that fit naturally alongside the existing publish/request/subscribe helpers.

## Validation
- `./mill zioNats.test`
